### PR TITLE
Add lower bound for fancycompleter, update dev_url

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm
   run:
     - python >={{ python_min }}
-    - fancycompleter
+    - fancycompleter >=0.11.0
     - wmctrl
     - pygments
 
@@ -49,7 +49,7 @@ about:
     This module is an extension of the pdb module of the standard library.
     It is meant to be fully compatible with its predecessor, yet it introduces
     a number of new features to make your debugging experience as nice as possible.
-  dev_url: https://github.com/pdbpp/pdbpp
+  dev_url: https://github.com/bretello/pdbpp
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Fixes Missing lower bound on fancycompleter #25.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
